### PR TITLE
Optimizer & opt.asm fixes

### DIFF
--- a/lib/opt/opt.asm
+++ b/lib/opt/opt.asm
@@ -5,7 +5,7 @@
     ; BYTES
     
     ; Quick addition
-    MAC pbytevar_pbyte_addbyte; @push
+    MAC pbytevar_pbyte_addbyte ; @push
     lda {1}
     clc
     adc #{2}
@@ -33,7 +33,7 @@
     ENDM
     
     ; Quick subtraction
-    MAC pbytevar_pbyte_subbyte; @push
+    MAC pbytevar_pbyte_subbyte ; @push
     lda {1}
     sec
     sbc #{2}
@@ -60,7 +60,7 @@
     ENDIF
     ENDM
     
-    ; Increase instad of addition
+    ; Increase instead of addition
     MAC pbytevar_pbyte_addbyte_plbytevar
     IF {1} == {3} && {2} == 1 ; Same vars and addend = 1
     inc {1}
@@ -83,7 +83,7 @@
     ENDIF
     ENDM
     
-    ; Decrease instad of subtraction
+    ; Decrease instead of subtraction
     MAC pbytevar_pbyte_subbyte_plbytevar
     IF {1} == {3} && {2} == 1 ; Same vars and addend = 1
     dec {1}
@@ -170,6 +170,20 @@
     ENDIF
     ENDM
     
+    ; ** fast casting for literals **
+
+    MAC pbyte_F_cint_byte ; @push
+    pint {1}
+    ENDM
+
+    MAC pbyte_F_cword_byte ; @push
+    pword {1}
+    ENDM
+
+    MAC pbyte_F_clong_byte ; @push
+    plong {1}
+    ENDM
+
     ; WORDS, INTS and DECIMALS
     
     ; Quick addition
@@ -206,10 +220,10 @@
     
     MAC pdecimal_pdecimalvar_adddecimal ; @push
     IF !USEIRQ
-	sei
-	ENDIF
+    sei
+    ENDIF
     sed
-    lda #{1}
+    lda #${1}
     clc
     adc {3}
     IF !FPUSH
@@ -217,7 +231,7 @@
     ELSE
     tax
     ENDIF
-    lda #{2}
+    lda #${2}
     adc {3} + 1
     IF !FPUSH
     pha
@@ -262,14 +276,14 @@
     
     MAC pdecimal_pdecimalvar_adddecimal_pldecimalvar
     IF !USEIRQ
-	sei
-	ENDIF
+    sei
+    ENDIF
     sed
-    lda #{1}
+    lda #${1}
     clc
     adc {3}
     sta {4}
-    lda #{2}
+    lda #${2}
     adc {3} + 1
     sta {4} + 1
     cld
@@ -311,19 +325,19 @@
     
     MAC pdecimalvar_pdecimal_adddecimal ; @push
     IF !USEIRQ
-	sei
-	ENDIF
+    sei
+    ENDIF
     sed
     lda {1}
     clc
-    adc #{2}
+    adc #${2}
     IF !FPUSH
     pha
     ELSE
     tax
     ENDIF
     lda {1} + 1
-    adc #{3}
+    adc #${3}
     IF !FPUSH
     pha
     ELSE
@@ -365,17 +379,17 @@
     pintvar_pint_addint_plintvar {1}, {2}, {3}
     ENDM
     
-    MAC pdecimalvar_pdecimal_addecimal_pldecimalvar
+    MAC pdecimalvar_pdecimal_adddecimal_pldecimalvar
     IF !USEIRQ
-	sei
-	ENDIF
+    sei
+    ENDIF
     sed
     lda {1}
     clc
-    adc #{2}
+    adc #${2}
     sta {4}
     lda {1} + 1
-    adc #{3}
+    adc #${3}
     sta {4} + 1
     cld
     IF !USEIRQ
@@ -408,8 +422,8 @@
     
     MAC pdecimalvar_pdecimalvar_adddecimal ; @push
     IF !USEIRQ
-	sei
-	ENDIF
+    sei
+    ENDIF
     sed
     pintvar_pintvar_addint {1}, {2}
     cld
@@ -428,16 +442,16 @@
     sta {3} + 1
     ENDM
     
-    MAC pwordvar_pwordvar_addword_plwordvar ; @push
-    pintvar_pintvar_addint {1}, {2}, {3}
+    MAC pwordvar_pwordvar_addword_plwordvar
+    pintvar_pintvar_addint_plintvar {1}, {2}, {3}
     ENDM
     
-    MAC pdecimalvar_pdecimalvar_adddecimal_pldecimalvar; @push
+    MAC pdecimalvar_pdecimalvar_adddecimal_pldecimalvar
     IF !USEIRQ
-	sei
-	ENDIF
+    sei
+    ENDIF
     sed
-    pintvar_pintvar_addint {1}, {2}, {3}
+    pintvar_pintvar_addint_plintvar {1}, {2}, {3}
     cld
     IF !USEIRQ
     cli
@@ -471,10 +485,10 @@
     
     MAC pdecimal_pdecimalvar_subdecimal ; @push
     IF !USEIRQ
-	sei
-	ENDIF
+    sei
+    ENDIF
     sed
-    lda #{1}
+    lda #${1}
     sec
     sbc {3}
     IF !FPUSH
@@ -482,7 +496,7 @@
     ELSE
     tax
     ENDIF
-    lda #{2}
+    lda #${2}
     sbc {3} + 1
     IF !FPUSH
     pha
@@ -512,14 +526,14 @@
     
     MAC pdecimal_pdecimalvar_subdecimal_pldecimalvar
     IF !USEIRQ
-	sei
-	ENDIF
+    sei
+    ENDIF
     sed
-    lda #{1}
+    lda #${1}
     sec
     sbc {3}
     sta {4}
-    lda #{2}
+    lda #${2}
     sbc {3} + 1
     sta {4} + 1
     cld
@@ -553,19 +567,19 @@
     
     MAC pdecimalvar_pdecimal_subdecimal ; @push
     IF !USEIRQ
-	sei
-	ENDIF
+    sei
+    ENDIF
     sed
     lda {1}
     sec
-    sbc #{2}
+    sbc #${2}
     IF !FPUSH
     pha
     ELSE
     tax
     ENDIF
     lda {1} + 1
-    sbc #{3}
+    sbc #${3}
     IF !FPUSH
     pha
     ELSE
@@ -594,15 +608,15 @@
     
     MAC pdecimalvar_pdecimal_subdecimal_pldecimalvar
     IF !USEIRQ
-	sei
-	ENDIF
+    sei
+    ENDIF
     sed
     lda {1}
     sec
-    sbc #{2}
+    sbc #${2}
     sta {4}
     lda {1} + 1
-    sbc #{3}
+    sbc #${3}
     sta {4} + 1
     cld
     IF !USEIRQ
@@ -635,8 +649,8 @@
     
     MAC pdecimalvar_pdecimalvar_subdecimal ; @push
     IF !USEIRQ
-	sei
-	ENDIF
+    sei
+    ENDIF
     sed
     pintvar_pintvar_subint {1}, {2}
     cld
@@ -661,8 +675,8 @@
     
     MAC pdecimalvar_pdecimalvar_subdecimal_pldecimalvar
     IF !USEIRQ
-	sei
-	ENDIF
+    sei
+    ENDIF
     sed
     pintvar_pintvar_subint_plintvar {1}, {2}, {3}
     cld
@@ -671,6 +685,44 @@
     ENDIF
     ENDM
     
+    ; ** fast casting for literals **
+
+    MAC pint_F_cbyte_int ; @push
+    pbyte <{1}
+    ENDM
+
+    MAC pint_F_cword_int ; @push
+    pword {1}
+    ENDM
+
+    MAC pint_F_clong_int ; @push
+    plong {1}
+    ENDM
+
+    MAC pword_F_cbyte_word ; @push
+    pbyte <{1}
+    ENDM
+
+    MAC pword_F_cint_word ; @push
+    pint {1}
+    ENDM
+
+    MAC pword_F_clong_word ; @push
+    plong {1}
+    ENDM
+
+    MAC plong_F_cbyte_long ; @push
+    pbyte <{1}
+    ENDM
+
+    MAC plong_F_cint_long ; @push
+    pint {1}
+    ENDM
+
+    MAC plong_F_cword_long ; @push
+    pword {1}
+    ENDM
+
     ; Array access
     
     MAC pbytevar_pbytearrayfast ; @push
@@ -682,557 +734,557 @@
     ENDM
     
     ; Quick comparison of bytes
-    
-	MAC pbyte_pbyte_cmpbyteeq ; @push
-	lda #{1}
-	cmp #{2}
-	beq .true
-	pfalse
-	beq .end
-.true:
-	ptrue
-.end
-	ENDM
-	
-	MAC pbytevar_pbyte_cmpbyteeq ; @push
-	lda {1}
-	cmp #{2}
-	beq .true
-	pfalse
-	beq .end
-.true:
-	ptrue
-.end
-	ENDM
-	
-	MAC pbyte_pbytevar_cmpbyteeq ; @push
-	lda #{1}
-	cmp {2}
-	beq .true
-	pfalse
-	beq .end
-.true:
-	ptrue
-.end
-	ENDM
-	
-	MAC pbytevar_pbytevar_cmpbyteeq ; @push
-	lda {1}
-	cmp {2}
-	beq .true
-	pfalse
-	beq .end
-.true:
-	ptrue
-.end
-	ENDM
-	
-	MAC pbyte_pbyte_cmpytebneq ; @push
-	lda #{1}
-	cmp #{2}
-	bne .true
-	pfalse
-	beq .end
-.true:
-	ptrue
-.end
-	ENDM
-	
-	MAC pbytevar_pbyte_cmpytebneq ; @push
-	lda {1}
-	cmp #{2}
-	bne .true
-	pfalse
-	beq .end
-.true:
-	ptrue
-.end
-	ENDM
-	
-	MAC pbyte_pbytevar_cmpytebneq ; @push
-	lda #{1}
-	cmp {2}
-	bne .true
-	pfalse
-	beq .end
-.true:
-	ptrue
-.end
-	ENDM
-	
-	MAC pbytevar_pbytevar_cmpytebneq ; @push
-	lda {1}
-	cmp {2}
-	bne .true
-	pfalse
-	beq .end
-.true:
-	ptrue
-.end
-	ENDM
 
-	MAC pbyte_pbyte_cmpbytelt ; @push
-	lda #{1}
-	cmp #{2}
-	bcs .false
-	ptrue
-	bne .end
-.false:
-	pfalse
-.end
-	ENDM
-	
-	MAC pbytevar_pbyte_cmpbytelt ; @push
-	lda {1}
-	cmp #{2}
-	bcs .false
-	ptrue
-	bne .end
-.false:
-	pfalse
-.end
-	ENDM
-	
-	MAC pbyte_pbytevar_cmpbytelt ; @push
-	lda #{1}
-	cmp {2}
-	bcs .false
-	ptrue
-	bne .end
-.false:
-	pfalse
-.end
-	ENDM
-	
-	MAC pbytevar_pbytevar_cmpbytelt ; @push
-	lda {1}
-	cmp {2}
-	bcs .false
-	ptrue
-	bne .end
-.false:
-	pfalse
-.end
-	ENDM
-	
-	MAC pbyte_pbyte_cmpbytelte ; @push
-	lda #{2}
-	cmp #{1}
-	bcs .true
-	pfalse
-	beq .end
+    MAC pbyte_pbyte_cmpbyteeq ; @push
+    lda #{1}
+    cmp #{2}
+    beq .true
+    pfalse
+    beq .end
 .true:
-	ptrue
+    ptrue
 .end
-	ENDM
-	
-	MAC pbyte_pbytevar_cmpbytelte ; @push
-	lda {2}
-	cmp #{1}
-	bcs .true
-	pfalse
-	beq .end
-.true:
-	ptrue
-.end
-	ENDM
-	
-	MAC pbytevar_pbyte_cmpbytelte ; @push
-	lda #{2}
-	cmp {1}
-	bcs .true
-	pfalse
-	beq .end
-.true:
-	ptrue
-.end
-	ENDM
-	
-	MAC pbytevar_pbytevar_cmpbytelte ; @push
-	lda {2}
-	cmp {1}
-	bcs .true
-	pfalse
-	beq .end
-.true:
-	ptrue
-.end
-	ENDM
-	
-	MAC pbyte_pbyte_cmpbbytegte ; @push
-	lda #{1}
-	cmp #{2}
-	bcs .true
-	pfalse
-	beq .end
-.true:
-	ptrue
-.end
-	ENDM
-	
-	MAC pbytevar_pbyte_cmpbbytegte ; @push
-	lda {1}
-	cmp #{2}
-	bcs .true
-	pfalse
-	beq .end
-.true:
-	ptrue
-.end
-	ENDM
-	
-	MAC pbyte_pbytevar_cmpbbytegte ; @push
-	lda #{1}
-	cmp {2}
-	bcs .true
-	pfalse
-	beq .end
-.true:
-	ptrue
-.end
-	ENDM
-	
-	MAC pbytevar_pbytevar_cmpbytegte ; @push
-	lda {1}
-	cmp {2}
-	bcs .true
-	pfalse
-	beq .end
-.true:
-	ptrue
-.end
-	ENDM
-	
-	MAC pbyte_pbyte_cmpbytegt ; @push
-	lda #{2}
-	cmp #{1}
-	bcc .true
-	pfalse
-	beq .end
-.true:
-	ptrue
-.end
-	ENDM
-	
-	MAC pbyte_pbytevar_cmpbytegt ; @push
-	lda {2}
-	cmp #{1}
-	bcc .true
-	pfalse
-	beq .end
-.true:
-	ptrue
-.end
-	ENDM
-	
-	MAC pbytevar_pbyte_cmpbytegt ; @push
-	lda #{2}
-	cmp {1}
-	bcc .true
-	pfalse
-	beq .end
-.true:
-	ptrue
-.end
-	ENDM
-	
-	MAC pbytevar_pbytevar_cmpbytegt ; @push
-	lda {2}
-	cmp {1}
-	bcc .true
-	pfalse
-	beq .end
-.true:
-	ptrue
-.end
-	ENDM
-	
-	 ; Quick comparison and branching
-	
-	MAC pbyte_pbyte_cmpbyteeq_cond_stmt
-	lda #{1}
-	cmp #{2}
-	beq .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
-.true:
-	ENDM
-	
-	MAC pbytevar_pbyte_cmpbyteeq_cond_stmt
-	lda {1}
-	cmp #{2}
-	beq .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
-.true:
-	ENDM
-	
-	MAC pbyte_pbytevar_cmpbyteeq_cond_stmt
-	lda #{1}
-	cmp {2}
-	beq .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
-.true:
-	ENDM
-	
-	MAC pbytevar_pbytevar_cmpbyteeq_cond_stmt
-	lda {1}
-	cmp {2}
-	beq .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
-.true:
-	ENDM
-	
-	MAC pbyte_pbyte_cmpytebneq_cond_stmt
-	lda #{1}
-	cmp #{2}
-	bne .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
-.true
-	ENDM
-	
-	MAC pbytevar_pbyte_cmpytebneq_cond_stmt
-	lda {1}
-	cmp #{2}
-	bne .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
-.true
-	ENDM
-	
-	MAC pbyte_pbytevar_cmpytebneq_cond_stmt
-	lda #{1}
-	cmp {2}
-	bne .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
-.true
-	ENDM
-	
-	MAC pbytevar_pbytevar_cmpytebneq_cond_stmt
-	lda {1}
-	cmp {2}
-	bne .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
-.true
-	ENDM
+    ENDM
 
-	MAC pbyte_pbyte_cmpbytelt_cond_stmt
-	lda #{1}
-	cmp #{2}
-	bcc .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
+    MAC pbytevar_pbyte_cmpbyteeq ; @push
+    lda {1}
+    cmp #{2}
+    beq .true
+    pfalse
+    beq .end
+.true:
+    ptrue
+.end
+    ENDM
+
+    MAC pbyte_pbytevar_cmpbyteeq ; @push
+    lda #{1}
+    cmp {2}
+    beq .true
+    pfalse
+    beq .end
+.true:
+    ptrue
+.end
+    ENDM
+
+    MAC pbytevar_pbytevar_cmpbyteeq ; @push
+    lda {1}
+    cmp {2}
+    beq .true
+    pfalse
+    beq .end
+.true:
+    ptrue
+.end
+    ENDM
+
+    MAC pbyte_pbyte_cmpbyteneq ; @push
+    lda #{1}
+    cmp #{2}
+    bne .true
+    pfalse
+    beq .end
+.true:
+    ptrue
+.end
+    ENDM
+
+    MAC pbytevar_pbyte_cmpbyteneq ; @push
+    lda {1}
+    cmp #{2}
+    bne .true
+    pfalse
+    beq .end
+.true:
+    ptrue
+.end
+    ENDM
+
+    MAC pbyte_pbytevar_cmpbyteneq ; @push
+    lda #{1}
+    cmp {2}
+    bne .true
+    pfalse
+    beq .end
+.true:
+    ptrue
+.end
+    ENDM
+
+    MAC pbytevar_pbytevar_cmpbyteneq ; @push
+    lda {1}
+    cmp {2}
+    bne .true
+    pfalse
+    beq .end
+.true:
+    ptrue
+.end
+    ENDM
+
+    MAC pbyte_pbyte_cmpbytelt ; @push
+    lda #{1}
+    cmp #{2}
+    bcs .false
+    ptrue
+    bne .end
+.false:
+    pfalse
+.end
+    ENDM
+
+    MAC pbytevar_pbyte_cmpbytelt ; @push
+    lda {1}
+    cmp #{2}
+    bcs .false
+    ptrue
+    bne .end
+.false:
+    pfalse
+.end
+    ENDM
+
+    MAC pbyte_pbytevar_cmpbytelt ; @push
+    lda #{1}
+    cmp {2}
+    bcs .false
+    ptrue
+    bne .end
+.false:
+    pfalse
+.end
+    ENDM
+
+    MAC pbytevar_pbytevar_cmpbytelt ; @push
+    lda {1}
+    cmp {2}
+    bcs .false
+    ptrue
+    bne .end
+.false:
+    pfalse
+.end
+    ENDM
+
+    MAC pbyte_pbyte_cmpbytelte ; @push
+    lda #{2}
+    cmp #{1}
+    bcs .true
+    pfalse
+    beq .end
+.true:
+    ptrue
+.end
+    ENDM
+
+    MAC pbyte_pbytevar_cmpbytelte ; @push
+    lda {2}
+    cmp #{1}
+    bcs .true
+    pfalse
+    beq .end
+.true:
+    ptrue
+.end
+    ENDM
+
+    MAC pbytevar_pbyte_cmpbytelte ; @push
+    lda #{2}
+    cmp {1}
+    bcs .true
+    pfalse
+    beq .end
+.true:
+    ptrue
+.end
+    ENDM
+
+    MAC pbytevar_pbytevar_cmpbytelte ; @push
+    lda {2}
+    cmp {1}
+    bcs .true
+    pfalse
+    beq .end
+.true:
+    ptrue
+.end
+    ENDM
+
+    MAC pbyte_pbyte_cmpbytegte ; @push
+    lda #{1}
+    cmp #{2}
+    bcs .true
+    pfalse
+    beq .end
+.true:
+    ptrue
+.end
+    ENDM
+
+    MAC pbytevar_pbyte_cmpbytegte ; @push
+    lda {1}
+    cmp #{2}
+    bcs .true
+    pfalse
+    beq .end
+.true:
+    ptrue
+.end
+    ENDM
+
+    MAC pbyte_pbytevar_cmpbytegte ; @push
+    lda #{1}
+    cmp {2}
+    bcs .true
+    pfalse
+    beq .end
+.true:
+    ptrue
+.end
+    ENDM
+
+    MAC pbytevar_pbytevar_cmpbytegte ; @push
+    lda {1}
+    cmp {2}
+    bcs .true
+    pfalse
+    beq .end
+.true:
+    ptrue
+.end
+    ENDM
+
+    MAC pbyte_pbyte_cmpbytegt ; @push
+    lda #{2}
+    cmp #{1}
+    bcc .true
+    pfalse
+    beq .end
+.true:
+    ptrue
+.end
+    ENDM
+
+    MAC pbyte_pbytevar_cmpbytegt ; @push
+    lda {2}
+    cmp #{1}
+    bcc .true
+    pfalse
+    beq .end
+.true:
+    ptrue
+.end
+    ENDM
+
+    MAC pbytevar_pbyte_cmpbytegt ; @push
+    lda #{2}
+    cmp {1}
+    bcc .true
+    pfalse
+    beq .end
+.true:
+    ptrue
+.end
+    ENDM
+
+    MAC pbytevar_pbytevar_cmpbytegt ; @push
+    lda {2}
+    cmp {1}
+    bcc .true
+    pfalse
+    beq .end
+.true:
+    ptrue
+.end
+    ENDM
+
+     ; Quick comparison and branching
+
+    MAC pbyte_pbyte_cmpbyteeq_cond_stmt
+    lda #{1}
+    cmp #{2}
+    beq .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
+.true:
+    ENDM
+
+    MAC pbytevar_pbyte_cmpbyteeq_cond_stmt
+    lda {1}
+    cmp #{2}
+    beq .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
+.true:
+    ENDM
+
+    MAC pbyte_pbytevar_cmpbyteeq_cond_stmt
+    lda #{1}
+    cmp {2}
+    beq .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
+.true:
+    ENDM
+
+    MAC pbytevar_pbytevar_cmpbyteeq_cond_stmt
+    lda {1}
+    cmp {2}
+    beq .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
+.true:
+    ENDM
+
+    MAC pbyte_pbyte_cmpbyteneq_cond_stmt
+    lda #{1}
+    cmp #{2}
+    bne .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
 .true
-	ENDM
-	
-	MAC pbytevar_pbyte_cmpbytelt_cond_stmt
-	lda {1}
-	cmp #{2}
-	bcc .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
+    ENDM
+
+    MAC pbytevar_pbyte_cmpbyteneq_cond_stmt
+    lda {1}
+    cmp #{2}
+    bne .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
 .true
-	ENDM
-	
-	MAC pbyte_pbytevar_cmpbytelt_cond_stmt
-	lda #{1}
-	cmp {2}
-	bcc .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
+    ENDM
+
+    MAC pbyte_pbytevar_cmpbyteneq_cond_stmt
+    lda #{1}
+    cmp {2}
+    bne .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
 .true
-	ENDM
-	
-	MAC pbytevar_pbytevar_cmpbytelt_cond_stmt
-	lda {1}
-	cmp {2}
-	bcc .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
+    ENDM
+
+    MAC pbytevar_pbytevar_cmpbyteneq_cond_stmt
+    lda {1}
+    cmp {2}
+    bne .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
 .true
-	ENDM
-	
-	MAC pbyte_pbyte_cmpbytelte_cond_stmt
-	lda #{2}
-	cmp #{1}
-	bcs .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
+    ENDM
+
+    MAC pbyte_pbyte_cmpbytelt_cond_stmt
+    lda #{1}
+    cmp #{2}
+    bcc .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
 .true
-	ENDM
-	
-	MAC pbyte_pbytevar_cmpbytelte_cond_stmt
-	lda {2}
-	cmp #{1}
-	bcs .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
+    ENDM
+
+    MAC pbytevar_pbyte_cmpbytelt_cond_stmt
+    lda {1}
+    cmp #{2}
+    bcc .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
 .true
-	ENDM
-	
-	MAC pbytevar_pbyte_cmpbytelte_cond_stmt
-	lda #{2}
-	cmp {1}
-	bcs .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
+    ENDM
+
+    MAC pbyte_pbytevar_cmpbytelt_cond_stmt
+    lda #{1}
+    cmp {2}
+    bcc .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
 .true
-	ENDM
-	
-	MAC pbytevar_pbytevar_cmpbytelte_cond_stmt
-	lda {2}
-	cmp {1}
-	bcs .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
+    ENDM
+
+    MAC pbytevar_pbytevar_cmpbytelt_cond_stmt
+    lda {1}
+    cmp {2}
+    bcc .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
 .true
-	ENDM
-	
-	MAC pbyte_pbyte_cmpbbytegte_cond_stmt
-	lda #{1}
-	cmp #{2}
-	bcs .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
+    ENDM
+
+    MAC pbyte_pbyte_cmpbytelte_cond_stmt
+    lda #{2}
+    cmp #{1}
+    bcs .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
 .true
-	ENDM
-	
-	MAC pbytevar_pbyte_cmpbbytegte_cond_stmt
-	lda {1}
-	cmp #{2}
-	bcs .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
+    ENDM
+
+    MAC pbyte_pbytevar_cmpbytelte_cond_stmt
+    lda {2}
+    cmp #{1}
+    bcs .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
 .true
-	ENDM
-	
-	MAC pbyte_pbytevar_cmpbbytegte_cond_stmt
-	lda #{1}
-	cmp {2}
-	bcs .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
+    ENDM
+
+    MAC pbytevar_pbyte_cmpbytelte_cond_stmt
+    lda #{2}
+    cmp {1}
+    bcs .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
 .true
-	ENDM
-	
-	MAC pbytevar_pbytevar_cmpbytegte_cond_stmt
-	lda {1}
-	cmp {2}
-	bcs .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
+    ENDM
+
+    MAC pbytevar_pbytevar_cmpbytelte_cond_stmt
+    lda {2}
+    cmp {1}
+    bcs .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
 .true
-	ENDM
-	
-	MAC pbyte_pbyte_cmpbytegt_cond_stmt
-	lda #{2}
-	cmp #{1}
-	bcc .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
+    ENDM
+
+    MAC pbyte_pbyte_cmpbytegte_cond_stmt
+    lda #{1}
+    cmp #{2}
+    bcs .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
 .true
-	ENDM
-	
-	MAC pbyte_pbytevar_cmpbytegt_cond_stmt
-	lda {2}
-	cmp #{1}
-	bcc .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
+    ENDM
+
+    MAC pbytevar_pbyte_cmpbytegte_cond_stmt
+    lda {1}
+    cmp #{2}
+    bcs .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
 .true
-	ENDM
-	
-	MAC pbytevar_pbyte_cmpbytegt_cond_stmt
-	lda #{2}
-	cmp {1}
-	bcc .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
+    ENDM
+
+    MAC pbyte_pbytevar_cmpbytegte_cond_stmt
+    lda #{1}
+    cmp {2}
+    bcs .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
 .true
-	ENDM
-	
-	MAC pbytevar_pbytevar_cmpbytegt_cond_stmt
-	lda {2}
-	cmp {1}
-	bcc .true
-	IF {4} > 0 && {2} < $10000
-	jmp {4}
-	ELSE
-	jmp {3}
-	ENDIF
+    ENDM
+
+    MAC pbytevar_pbytevar_cmpbytegte_cond_stmt
+    lda {1}
+    cmp {2}
+    bcs .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
 .true
-	ENDM
+    ENDM
+
+    MAC pbyte_pbyte_cmpbytegt_cond_stmt
+    lda #{2}
+    cmp #{1}
+    bcc .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
+.true
+    ENDM
+
+    MAC pbyte_pbytevar_cmpbytegt_cond_stmt
+    lda {2}
+    cmp #{1}
+    bcc .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
+.true
+    ENDM
+
+    MAC pbytevar_pbyte_cmpbytegt_cond_stmt
+    lda #{2}
+    cmp {1}
+    bcc .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
+.true
+    ENDM
+
+    MAC pbytevar_pbytevar_cmpbytegt_cond_stmt
+    lda {2}
+    cmp {1}
+    bcc .true
+    IF {4} > 0 && {4} < $10000
+    jmp {4}
+    ELSE
+    jmp {3}
+    ENDIF
+.true
+    ENDM

--- a/source/optimizer.d
+++ b/source/optimizer.d
@@ -107,24 +107,19 @@ class ReplaceSequences: OptimizerPass
     private int replaceSequences()
     {
         bool optEnabled = false;
-        int replacementsMade = false;
+        int replacementsMade = 0;
         string[] lines = splitLines(this.inCode);
         opCode[] accumulatedSequence;
         string[] accumulatedCode;
 
+        size_t fullMatchLength = 0;
+
         this.outCode = "";
+
         for(int i = 0; i < lines.length; i++) {
             string line = lines[i];
             if(line == "    ; !!opt_start!!") {
                 optEnabled = true;
-                this.outCode ~= line ~ "\n";
-                continue;
-            }
-            else if(line == "    ; !!opt_end!!") {
-                optEnabled = false;
-                this.outCode ~= join(accumulatedCode, "\n") ~ "\n" ~ line ~ "\n";
-                accumulatedSequence = [];
-                accumulatedCode = [];
                 this.outCode ~= line ~ "\n";
                 continue;
             }
@@ -134,43 +129,61 @@ class ReplaceSequences: OptimizerPass
                 continue;
             }
 
-            auto expr = regex(r"\s+([a-zA-Z0-9_@]+)(\s.+)?");
+            accumulatedCode ~= line;
+
+            auto expr = regex(r"^\s+([a-zA-Z0-9_@]+)\s*(.+)?");
             auto match = matchFirst(line, expr);
-            if(match && !this.fullMatch(match[1])) {
-                accumulatedCode ~= line;
-                string opcodeStr = match[1];
-                string arg = "";
-                if(match.length > 2) {
-                    arg = match[2];
-                }
 
-                opCode op = {opcodeStr, arg};
-                accumulatedSequence ~= op;
-                string seqString = this.stringifySequence(accumulatedSequence);
+            string opcodeStr;
+            string arg = "";
 
-                if(this.matchSequences(seqString)) {
-                    //stderr.writeln("match: " ~ seqString);
-                    if(this.fullMatch(seqString)) {
-                        //stderr.writeln("replace: " ~ seqString);
-                        this.outCode ~= "    " ~ seqString ~ " " ~ this.stringifyArgs(accumulatedSequence) ~ "\n";
-                        accumulatedSequence = [];
-                        accumulatedCode = [];
-                        replacementsMade++;
-                    }
-                }
-                else {
-                    //stderr.writeln("no match: " ~ seqString);
-                    this.outCode ~= accumulatedCode[0] ~ "\n";
-                    accumulatedSequence = accumulatedSequence.remove(0);
-                    accumulatedCode = accumulatedCode.remove(0);
-                }
+            if(match) {
+                opcodeStr = match[1];
+                arg = match[2];
             }
             else {
-                //stderr.writeln("break: " ~ line);
-                this.outCode ~= join(accumulatedCode, "\n") ~ "\n" ~ line ~ "\n";
-                accumulatedSequence = [];
-                accumulatedCode = [];
+                opcodeStr = "$NOOPCODE$";
             }
+
+            opCode op = {opcodeStr, arg};
+            accumulatedSequence ~= op;
+
+            string seqString = this.stringifySequence(accumulatedSequence);
+
+            if(this.matchSequences(seqString)) {
+                if(this.fullMatch(seqString)) { fullMatchLength = accumulatedSequence.length; }
+            }
+            else {
+                // Flush the Accumulator
+
+                if(fullMatchLength > 0) {
+                    this.outCode ~= "    " ~ this.stringifySequence(accumulatedSequence[0 .. fullMatchLength]) ~ " " ~ this.stringifyArgs(accumulatedSequence[0 .. fullMatchLength ]) ~ "\n";
+                    accumulatedSequence = accumulatedSequence[fullMatchLength .. $];
+                    accumulatedCode = accumulatedCode[fullMatchLength .. $];
+
+                    // if (fullMatchLength > 1) {replacementsMade++;}
+                    fullMatchLength = 0;
+                }
+                else {
+                    if (accumulatedCode[0] == "    ; !!opt_end!!") {
+                        this.outCode ~= join(accumulatedCode, "\n") ~ "\n";
+                        accumulatedSequence = [];
+                        accumulatedCode = [];
+                        optEnabled = false;
+                    }
+                    else {
+                        this.outCode ~= accumulatedCode[0] ~ "\n";
+                        accumulatedSequence = accumulatedSequence.remove(0);
+                        accumulatedCode = accumulatedCode.remove(0);
+                    }
+                }
+
+                for(int j = 2; j <= accumulatedSequence.length; j++) {
+                    seqString = this.stringifySequence(accumulatedSequence[0 .. j]);
+                    if(this.fullMatch(seqString)) { fullMatchLength = j ; }
+                }
+            }
+
         }
 
         return replacementsMade;
@@ -180,9 +193,9 @@ class ReplaceSequences: OptimizerPass
     {
         this.fetchSequences();
         int replacementsMade;
-        int i = 0;
+        // int i = 0;
         do {
-            i++;
+            // i++;
             replacementsMade = this.replaceSequences();
             import std.conv;
             //stderr.writeln("Pass " ~ to!string(i) ~ ": " ~ to!string(replacementsMade));
@@ -266,7 +279,7 @@ class RemoveStackOps: OptimizerPass
                     next_opc = this.getOpcode(next_line);
                     j++;
                 }
-                while(next_line == "");
+                while(next_line == "" || next_line.startsWith(";"));
 
                 if(this.isPuller(opc) && pushf) {
                     if(!pullf) {


### PR DESCRIPTION
This applies many corrections to the `opt.asm` ASM library file, and also features a partial rewrite of the `replaceSequences` function in the Optimizer itself.

I also added macros to make DASM do literal value casts at assemble-time rather than runtime; I'm not sure that doesn't break the original Optimizer. I believe that both files should be applied to the codebase.